### PR TITLE
feat: add hash navigation to build page

### DIFF
--- a/src/components/CodeEditor/utils/codeEditorTypes/tensorflow.d.ts
+++ b/src/components/CodeEditor/utils/codeEditorTypes/tensorflow.d.ts
@@ -3,7 +3,7 @@
  */
 declare interface LayersModel {
   predict(tensor: Tensor): Tensor;
-  fit(x: Tensor | Tensor[], y: Tensor | Tensor[][], ModelFitArgs): Promise<History>;
+  fit(inputs: Tensor, outputs: Tensor, ModelFitArgs): Promise<History>;
   compile(arg0: {
     // Adam changes the learning rate over time which is useful.
     // optimizer: 'adam',
@@ -38,9 +38,9 @@ declare interface History {
    * Await the values of all losses and metrics.
    */
   syncData(): Promise<void>;
-  params?: {
-    samples?: number;
-  };
+  params?: ModelFitArgs;
+  input: Tensor;
+  output: Tensor;
 }
 
 declare interface Tensor {
@@ -72,7 +72,7 @@ declare type ActivationIdentifier =
   | 'tanh'
   | 'swish'
   | 'mish';
-interface ModelFitArgs {
+declare interface ModelFitArgs {
   batchSize?: number;
   epochs?: number;
   verbose?: 0 | 1;

--- a/src/layout/train.html
+++ b/src/layout/train.html
@@ -3,8 +3,8 @@
   <fluent-breadcrumb>
     {{#each settings.trainTutorialSteps}}
     <fluent-breadcrumb-item id="tutorial-step{{this.step}}">
-      <!-- <a href="#step{{this.step}}">{{this.description}}</a> -->
-      {{this.description}}
+      <a href="#step{{this.step}}">{{this.description}}</a>
+      <!-- {{this.description}} -->
     </fluent-breadcrumb-item>
     {{/each}}
   </fluent-breadcrumb>
@@ -60,10 +60,6 @@
 
     </fluent-tab-panel>
     <fluent-tab-panel id="instructionPanel">
-
-      <!-- <div class="load-data-description">
-          <image src="/instructions/loadData.png" height="600px" />
-        </div> -->
 
       {{#if settings.trainTutorialSteps}}
       {{#each settings.trainTutorialSteps}}

--- a/src/pages/train/BuildState.ts
+++ b/src/pages/train/BuildState.ts
@@ -1,0 +1,246 @@
+import type { LayersModel } from '@tensorflow/tfjs';
+
+import type { TrainTutorialSteps, ValidationResult } from '../../types';
+import { getOrCreateElement, millisToMinutesAndSeconds } from '../../utils/utils';
+import { exportModel, trainModelSolution } from './train';
+import { getSuccessStatement, handleValidationgComplete } from './utils/dataLoader';
+
+const DefaultEpoch = 5;
+interface ModelBuilderOptions {
+  epochs?: number;
+}
+
+interface TrainingCallbacks {
+  onBatchEnd: (batch: number, logs?: Logs) => void;
+  onEpochEnd: (epoch: number) => void;
+}
+
+export class BuildState {
+  #epochs = DefaultEpoch;
+  #batchSize = 128;
+  #currentEpochCount = 1;
+  #startBatchTime = 0;
+
+  #currentStep?: TrainTutorialSteps;
+
+  #trainingEnabled = true;
+  #trainingStatusElement = getOrCreateElement('.training-feedback-container') as HTMLElement;
+  #timeElement = getOrCreateElement('.training-progress-bar') as HTMLElement;
+  #startTrainingButton = getOrCreateElement('.training-start-button') as HTMLButtonElement;
+  #stopTrainingButton = getOrCreateElement('.training-stop-button') as HTMLButtonElement;
+
+  #trainingComplete = false;
+
+  #stepCompleted: Record<string, boolean> = {};
+
+  #data?: [number[][], number[][], number[][], number[][]]; //[X_train, X_val, y_train, y_val]
+
+  #aslModel: LayersModel | undefined;
+
+  constructor(options?: ModelBuilderOptions) {
+    this.#epochs = options?.epochs ?? DefaultEpoch;
+  }
+
+  set aslModel(model: LayersModel | undefined) {
+    this.#aslModel = model;
+  }
+
+  get aslModel(): LayersModel | undefined {
+    return this.#aslModel;
+  }
+
+  set currentStep(step: TrainTutorialSteps | undefined) {
+    this.#currentStep = step;
+  }
+
+  get currentStep() {
+    return this.#currentStep;
+  }
+
+  get step() {
+    return this.#currentStep?.step;
+  }
+
+  get stepName() {
+    return this.#currentStep?.name;
+  }
+
+  get epochs() {
+    return this.#epochs;
+  }
+
+  completedValidation(name: string, state: boolean) {
+    this.#stepCompleted[name] = state;
+  }
+
+  getCompletedState(name: string): boolean {
+    return this.#stepCompleted[name] ?? false;
+  }
+
+  handleReset(name: string) {
+    if (name === 'createModel') {
+      this.#aslModel = undefined;
+    }
+    this.completedValidation(name, false);
+  }
+
+  getTrainingData(): { inputs: number[][]; outputs: number[][] } | undefined {
+    if (this.#data) {
+      const [x_train, x_val, y_train, y_val] = this.#data!;
+      return { inputs: x_train, outputs: y_train };
+    }
+  }
+
+  getValidationData(): { inputs: number[][]; outputs: number[][] } | undefined {
+    if (this.#data) {
+      //[X_train, X_val, y_train, y_val];
+      const [x_train, x_val, y_train, y_val] = this.#data;
+      return { inputs: x_val, outputs: y_val };
+    }
+  }
+
+  handleModelResults = (result: ValidationResult) => {
+    if (result.valid && result.data && result.data.length > 0) {
+      this.#aslModel = result.data[0] as unknown as LayersModel;
+    }
+  };
+
+  handleModelCreation = (result: ValidationResult) => {
+    if (result.valid && result.data && result.data.length > 0) {
+      this.#aslModel = result.data[0] as unknown as LayersModel;
+    } else {
+      console.log('no data provided to ModelBuilder, please retry load data function');
+    }
+  };
+
+  handleDataSplitValidation = (result: ValidationResult) => {
+    if (result.valid && result.data && result.data.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      this.#data = result.data[0];
+    } else {
+      console.log('no data provided to ModelBuilder, please retry load data function');
+    }
+  };
+
+  handleTrainValidation = (result: ValidationResult) => {
+    if (result.valid && result.data && result.data.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const [batchSize, epochs] = result.data as [number, number];
+      this.#batchSize = batchSize;
+      this.#epochs = epochs;
+    } else {
+      console.log('no data provided to ModelBuilder, please retry load data function');
+    }
+  };
+
+  onBatchEnd = (batch: number, logs?: Logs) => {
+    this.#trainingStatusElement.style.display = 'inline-block';
+
+    if (!this.#trainingEnabled && this.#aslModel) {
+      this.#aslModel.stopTraining = true;
+    }
+
+    this.#trainingStatusElement.innerHTML = `
+      Epoch: ${this.#currentEpochCount} Batch: ${batch}
+      <br>
+      Loss: ${logs?.loss.toFixed(3) ?? ''}
+      <br>
+      Accuracy: ${logs?.acc.toFixed(3) ?? ''}
+      <br>
+      `;
+  };
+
+  async onDownload() {
+    const model = this.#aslModel;
+    if (model) {
+      await exportModel(model);
+      handleValidationgComplete(this.step ?? 1, true, getSuccessStatement('exportModel'));
+    } else {
+      handleValidationgComplete(this.step ?? 1, false, 'no model loaded');
+    }
+  }
+
+  onEpochEnd = (epoch: number) => {
+    const batchDuration = Date.now() - this.#startBatchTime;
+    this.#currentEpochCount = epoch + 2;
+    const remainingIncrements = this.#epochs - epoch;
+    const msRemaining = batchDuration * remainingIncrements;
+    const [time, hasMinutes] = millisToMinutesAndSeconds(msRemaining);
+
+    this.#timeElement.innerHTML = `${time} ${hasMinutes ? 'minutes' : 'seconds'} remaining`;
+    this.#startBatchTime = Date.now();
+    if (epoch === this.#epochs - 1) {
+      this.#trainingComplete = true;
+      handleValidationgComplete(this.step ?? 1, true, getSuccessStatement('trainModel'));
+    }
+  };
+
+  getCallbacks(): TrainingCallbacks {
+    return { onBatchEnd: this.onBatchEnd, onEpochEnd: this.onEpochEnd };
+  }
+
+  handleValidationComplete = (name: string, step: number, passedValidation: boolean) => {
+    if (this.#currentStep?.step === step) {
+      const successStatement = passedValidation ? getSuccessStatement(name) : 'validation failed';
+
+      if (passedValidation && name === 'trainModel') {
+        this.enableTrainingButtons();
+      } else {
+        this.disableTrainingButtons();
+      }
+
+      if (name !== 'exportModel' && name !== 'trainModel') {
+        handleValidationgComplete(step, passedValidation, successStatement);
+      }
+    }
+  };
+
+  disableTrainingButtons() {
+    this.#startTrainingButton.disabled = true;
+    this.#stopTrainingButton.disabled = true;
+  }
+
+  enableTrainingButtons() {
+    this.#startTrainingButton.disabled = false;
+    this.#stopTrainingButton.disabled = false;
+  }
+  handleTrainingStopped() {
+    this.#trainingEnabled = false;
+    this.#startTrainingButton.disabled = false;
+    this.#trainingComplete = true;
+    handleValidationgComplete(this.step ?? 1, true, getSuccessStatement('trainModel'));
+  }
+
+  getTrainingInputs(): [
+    LayersModel | undefined,
+    { inputs: number[][]; outputs: number[][] } | undefined,
+    { inputs: number[][]; outputs: number[][] } | undefined,
+    TrainingCallbacks,
+    number,
+  ] {
+    return [
+      this.#aslModel,
+      this.getTrainingData(),
+      this.getValidationData(),
+      this.getCallbacks(),
+      this.#epochs,
+    ];
+  }
+
+  async onTrainingClick() {
+    const [model, trainingData, validationData, cbs, epochs] = this.getTrainingInputs();
+    if (model) {
+      model.stopTraining = false;
+      this.#trainingEnabled = true;
+      this.#currentEpochCount = 1;
+      this.#startTrainingButton.disabled = true;
+      this.#trainingComplete = false;
+
+      await trainModelSolution(model, trainingData, validationData, cbs, epochs, this.#batchSize);
+    }
+  }
+
+  set trainingEnabled(state: boolean) {
+    this.#trainingEnabled = state;
+  }
+}

--- a/src/pages/train/BuildState.ts
+++ b/src/pages/train/BuildState.ts
@@ -29,7 +29,7 @@ export class BuildState {
   #startTrainingButton = getOrCreateElement('.training-start-button') as HTMLButtonElement;
   #stopTrainingButton = getOrCreateElement('.training-stop-button') as HTMLButtonElement;
 
-  #trainingComplete = false;
+  //   #trainingComplete = false;
 
   #stepCompleted: Record<string, boolean> = {};
 
@@ -86,17 +86,19 @@ export class BuildState {
 
   getTrainingData(): { inputs: number[][]; outputs: number[][] } | undefined {
     if (this.#data) {
-      const [x_train, x_val, y_train, y_val] = this.#data!;
+      const [x_train, , y_train] = this.#data!;
       return { inputs: x_train, outputs: y_train };
     }
+    return;
   }
 
   getValidationData(): { inputs: number[][]; outputs: number[][] } | undefined {
     if (this.#data) {
       //[X_train, X_val, y_train, y_val];
-      const [x_train, x_val, y_train, y_val] = this.#data;
+      const [, x_val, , y_val] = this.#data;
       return { inputs: x_val, outputs: y_val };
     }
+    return;
   }
 
   handleModelResults = (result: ValidationResult) => {
@@ -170,7 +172,7 @@ export class BuildState {
     this.#timeElement.innerHTML = `${time} ${hasMinutes ? 'minutes' : 'seconds'} remaining`;
     this.#startBatchTime = Date.now();
     if (epoch === this.#epochs - 1) {
-      this.#trainingComplete = true;
+      //   this.#trainingComplete = true;
       handleValidationgComplete(this.step ?? 1, true, getSuccessStatement('trainModel'));
     }
   };
@@ -207,7 +209,7 @@ export class BuildState {
   handleTrainingStopped() {
     this.#trainingEnabled = false;
     this.#startTrainingButton.disabled = false;
-    this.#trainingComplete = true;
+    // this.#trainingComplete = true;
     handleValidationgComplete(this.step ?? 1, true, getSuccessStatement('trainModel'));
   }
 
@@ -234,7 +236,7 @@ export class BuildState {
       this.#trainingEnabled = true;
       this.#currentEpochCount = 1;
       this.#startTrainingButton.disabled = true;
-      this.#trainingComplete = false;
+      //   this.#trainingComplete = false;
 
       await trainModelSolution(model, trainingData, validationData, cbs, epochs, this.#batchSize);
     }

--- a/src/pages/train/ElementViewer.ts
+++ b/src/pages/train/ElementViewer.ts
@@ -1,0 +1,89 @@
+import type { Tab } from '@fluentui/web-components';
+
+import type { CodeStepComponent } from '../../components';
+import { getOrCreateElement } from '../../utils/utils';
+
+export class ElementViewer {
+  #mainEle = getOrCreateElement('#output-element') as HTMLElement;
+  #trainingStatusElement = getOrCreateElement('.training-feedback-container') as HTMLElement;
+  #codeStepEles = document.querySelectorAll('code-step') as NodeListOf<CodeStepComponent>;
+  #solutionTabPanel = getOrCreateElement('#solution-tab') as Tab;
+
+  #actionButton = getOrCreateElement('.train-button') as HTMLButtonElement;
+  #resetButton = getOrCreateElement('.reset-button') as HTMLButtonElement;
+  #stopTrainingButton = getOrCreateElement('.training-stop-button') as HTMLButtonElement;
+  #startTrainingButton = getOrCreateElement('.training-start-button') as HTMLButtonElement;
+  #downloadButton = getOrCreateElement('.download-button') as HTMLButtonElement;
+  #solveButton = getOrCreateElement('.solve-button') as HTMLButtonElement;
+
+  showTrainingButtons() {
+    this.#startTrainingButton.style.display = 'inline-flex';
+    this.#stopTrainingButton.style.display = 'inline-flex';
+  }
+
+  hideTrainingButtons() {
+    this.#stopTrainingButton.style.display = 'none';
+    this.#startTrainingButton.style.display = 'none';
+    this.#trainingStatusElement.style.display = 'none';
+  }
+
+  showTrainingOutput() {
+    this.#trainingStatusElement.style.display = 'inline-block';
+  }
+
+  hideTrainingOutput() {
+    this.#trainingStatusElement.style.display = 'none';
+  }
+
+  showDownload() {
+    this.#downloadButton.style.display = 'inline-flex';
+  }
+  hideDownload() {
+    this.#downloadButton.style.display = 'none';
+  }
+
+  hideCodeButtons() {
+    this.#resetButton.style.display = 'none';
+    this.#solveButton.style.display = 'none';
+    this.#solutionTabPanel.style.display = 'none';
+  }
+
+  showCodeButtons() {
+    this.#resetButton.style.display = 'inline-flex';
+    this.#solveButton.style.display = 'inline-flex';
+    this.#solutionTabPanel.style.display = 'inline-flex';
+  }
+  hideNextButton() {
+    this.#actionButton.style.display = 'none';
+  }
+
+  showNextButton() {
+    this.#actionButton.style.display = 'inline-flex';
+  }
+
+  showInstructions(name: string) {
+    const instructionsContainer = getOrCreateElement(`#${name}-image`) as HTMLElement;
+    instructionsContainer.style.display = 'flex';
+  }
+
+  hideInstructions(name: string) {
+    const instructionsContainer = getOrCreateElement(`#${name}-image`) as HTMLElement;
+    instructionsContainer.style.display = 'none';
+  }
+}
+
+// Utils
+
+export function highlightNavStep(step: number): void {
+  const step1Element: HTMLElement | null = document.querySelector(`#tutorial-step${step}`);
+  if (step1Element) {
+    step1Element.style.fontWeight = 'bold';
+  }
+}
+
+export function unhighlightNavStep(step: number): void {
+  const step1Element: HTMLElement | null = document.querySelector(`#tutorial-step${step}`);
+  if (step1Element) {
+    step1Element.style.fontWeight = 'revert';
+  }
+}

--- a/src/pages/train/ElementViewer.ts
+++ b/src/pages/train/ElementViewer.ts
@@ -1,12 +1,9 @@
 import type { Tab } from '@fluentui/web-components';
 
-import type { CodeStepComponent } from '../../components';
 import { getOrCreateElement } from '../../utils/utils';
 
 export class ElementViewer {
-  #mainEle = getOrCreateElement('#output-element') as HTMLElement;
   #trainingStatusElement = getOrCreateElement('.training-feedback-container') as HTMLElement;
-  #codeStepEles = document.querySelectorAll('code-step') as NodeListOf<CodeStepComponent>;
   #solutionTabPanel = getOrCreateElement('#solution-tab') as Tab;
 
   #actionButton = getOrCreateElement('.train-button') as HTMLButtonElement;

--- a/src/pages/train/ModelBuilder.ts
+++ b/src/pages/train/ModelBuilder.ts
@@ -12,7 +12,6 @@ import type { CodeStepRecord } from './codeSteps';
 import { codeSteps } from './codeSteps';
 import { ElementViewer, highlightNavStep, unhighlightNavStep } from './ElementViewer';
 import { StepViewer, Validated } from './StepViewer';
-import { exportModel } from './train';
 import { clearValidationFeedback, handleNavReset } from './utils/dataLoader';
 
 const ProjectSettingsConfig = Settings as unknown as ProjectSettings;

--- a/src/pages/train/StepViewer.ts
+++ b/src/pages/train/StepViewer.ts
@@ -84,6 +84,10 @@ export class StepViewer {
     return this.#solutionElement;
   }
 
+  get stepCount(): number {
+    return this.#stepCount;
+  }
+
   resetCodeToDefault() {
     this.code = this.#stepRecord.template;
     localStorage.removeItem(`build:${this.#name}`);
@@ -122,6 +126,8 @@ export class StepViewer {
         if (!this.#overrideEventListener) {
           await this.handleEvalInput(code);
         }
+      } else {
+        this.#emitter.emit(ValidationComplete, this.#name, this.#stepCount, false);
       }
     });
   }

--- a/src/pages/train/codeSteps/trainModel.ts
+++ b/src/pages/train/codeSteps/trainModel.ts
@@ -1,5 +1,4 @@
 import * as tf from '@tensorflow/tfjs';
-import { sequential } from '@tensorflow/tfjs';
 
 import type { ValidationResult } from '../../../types';
 import { ValidationErrorType } from '../../../types';

--- a/src/pages/train/main.ts
+++ b/src/pages/train/main.ts
@@ -13,3 +13,16 @@ void ModelBuilderInstance.init();
 
 // Test full pipeline without code-blocks
 // void testFullPipeline();
+
+/**
+ * Loads the step number from the url hash
+ * @returns The step number
+ */
+function loadStepFromHash(): number {
+  const hash = window.location.hash ?? null;
+  return +(hash.replace('#step', '') || '1');
+}
+// Listen to the hash change, and update the current step
+window.addEventListener('hashchange', () => ModelBuilderInstance.onStepChange(loadStepFromHash()));
+
+void ModelBuilderInstance.onStepChange(loadStepFromHash());

--- a/src/pages/train/train.ts
+++ b/src/pages/train/train.ts
@@ -292,7 +292,7 @@ export async function trainModelSolution(
   const inputValidation = tf.tensor(validationData.inputs);
   const outputValidation = tf.tensor(validationData.outputs);
 
-  await model.fit(inputs, outputs, {
+  const modelHistory = await model.fit(inputs, outputs, {
     epochs: numEpochs,
     batchSize,
     verbose: 1,
@@ -304,4 +304,6 @@ export async function trainModelSolution(
   outputs.dispose();
   inputValidation.dispose();
   outputValidation.dispose();
+
+  return modelHistory;
 }

--- a/src/pages/train/utils/dataLoader.ts
+++ b/src/pages/train/utils/dataLoader.ts
@@ -30,11 +30,20 @@ export function handleValidationgComplete(
     const breadcrumbItem = getOrCreateElement(`#tutorial-step${step}`) as BreadcrumbItem;
     const description = Settings.trainTutorialSteps.find((item) => item.step === step);
     if (description && breadcrumbItem) {
-      breadcrumbItem.innerHTML = `✅${description.description}`;
+      breadcrumbItem.innerHTML = `<a href="#step${step}">✅${description.description}</a>`;
     }
     const actionButton = getOrCreateElement(actionButtonQuery) as HTMLButtonElement;
     actionButton.disabled = false;
   }
+}
+
+export function handleNavReset(step: number) {
+  const breadcrumbItem = getOrCreateElement(`#tutorial-step${step}`) as BreadcrumbItem;
+  const description = Settings.trainTutorialSteps.find((item) => item.step === step);
+  if (description && breadcrumbItem) {
+    breadcrumbItem.innerHTML = `<a href="#step${step}">${description.description}</a>`;
+  }
+  clearValidationFeedback();
 }
 
 export function clearValidationFeedback() {


### PR DESCRIPTION
Adds links to breadcrumbs in buildpage.
Breaks out ModelBuilder to handle state and some element displaying in separate classes. For trainModel, mock function was used for validation and then passed parameters inputted by user to function. Modified download button to execute function instead of code step. 

This still expects to go in order of steps but is more flexible in navigation. 